### PR TITLE
Changed "null" values to empty array value [ ]

### DIFF
--- a/config/authority.toml
+++ b/config/authority.toml
@@ -26,7 +26,7 @@ path = "/root/.local/share/io.parity.ethereum/signer"
 disable = false
 port = 8545
 interface = "0.0.0.0"
-cors = "null"
+cors = [ ]
 apis = ["web3", "eth", "net", "parity", "traces", "rpc", "secretstore"]
 hosts = ["none"]
 
@@ -60,7 +60,7 @@ path = "/root/.local/share/io.parity.ethereum/secretstore"
 enable = false
 port = 5001
 interface = "0.0.0.0"
-cors = "null"
+cors = [ ]
 hosts = ["none"]
 
 [network]


### PR DESCRIPTION
Error on startup execution of ewf-run.sh  "invalid type: string "null", expected a sequence for key `rpc.cors'"

Changed 2 values from "null" to empty array [ ] as described here:
https://github.com/paritytech/parity/issues/7734

authority node successfully launches after this change.