### PR TITLE
update to new netstats host

### DIFF
--- a/skel/eth-netstats.json
+++ b/skel/eth-netstats.json
@@ -16,7 +16,7 @@
       "LISTENING_PORT"  : "30303",
       "INSTANCE_NAME"   : "Test - Please change",
       "CONTACT_DETAILS" : "test@ewf.org - Please change",
-      "WS_SERVER"       : "34.227.66.228:80",
+      "WS_SERVER"       : "ws://46.38.232.222:8080",
       "WS_SECRET"       : "0k8H6F4s",
       "VERBOSITY"       : 3
     }

--- a/updater.sh
+++ b/updater.sh
@@ -250,9 +250,9 @@ done
 #     sudo systemctl start ewf-tobalaba-authority@ewf.service
 #fi
 
-sudo systemctl stop ewf-tobalaba-authority@ewf.service
+#sudo systemctl stop ewf-tobalaba-authority@ewf.service
 # docker pull parity/parity:nightly
-sudo systemctl start ewf-tobalaba-authority@ewf.service
+#sudo systemctl start ewf-tobalaba-authority@ewf.service
 
 # if grep 'TWL' ../authority_node/monitor/app.json
 # then
@@ -260,6 +260,20 @@ sudo systemctl start ewf-tobalaba-authority@ewf.service
 #     cp ./skel/authority.yml ../authority_node/docker-compose.yml
 #     sudo systemctl start ewf-tobalaba-authority@ewf.service
 # fi
+
+### 2019-01-21 Update Netstats to Slock.it Infrastructure
+
+# Update host in eth-netstats.json
+
+if grep 'innogy authority node Tobalaba Net' ../authority_node/monitor/app.json
+then
+    cp ../authority_node/monitor/app.json ../authority_node/monitor/app.json.bak-20190121
+    sed -i 's/WS_SERVER.*/WS_SERVER\"\t\: \"ws\:\/\/46.38.232.222\:8080",/' ../authority_node/monitor/app.json
+    sudo systemctl restart ewf-tobalaba-authority@ewf.service
+fi
+
+
+### UPDATE END
 
 echo "$(date)" > ../authority_node/latest_update
  


### PR DESCRIPTION
Switch netstats to slock.it infrastructure.

Innogy as guinea pig.